### PR TITLE
SplitView now uses 1-pixel-wide divider

### DIFF
--- a/src/sidebar/CWTMSplitView.mm
+++ b/src/sidebar/CWTMSplitView.mm
@@ -40,7 +40,7 @@
 
 - (float)dividerThickness
 {
-    return 8;
+    return 1;
 }
 
 - (BOOL)sideBarOnRight;

--- a/src/sidebar/KFSplitView.m
+++ b/src/sidebar/KFSplitView.m
@@ -166,6 +166,8 @@ static BOOL kfScaleUInts(unsigned *integers, int numInts, unsigned targetTotal)
 
 - (void)kfSetup
 {
+    [self setDividerStyle:NSSplitViewDividerStyleThin];
+	
     // be sure to setup cursors before calling setVertical:
     [self kfSetupResizeCursors];
 


### PR DESCRIPTION
I updated the NSSplitView/MMKFSplitView to use the 1-pixel-wide divider style (as seen in Mail.app, etc.) This should be more in keeping with OS X HIG.
